### PR TITLE
Allow passing a custom `Agent` in options

### DIFF
--- a/src/RestClient.js
+++ b/src/RestClient.js
@@ -17,7 +17,7 @@ class RestClient {
 		this.type = typeof options.type === "string" && options.type.toLowerCase() === "bearer" ? "Bearer" : "Bot";
 		this.retries = Number(options.retries) || 3;
 		this.timeout = Number(options.timeout) || 10000;
-		/** @private */ this._agent = new Agent({ keepAlive: true });
+		this.agent = options.agent || new Agent({ keepAlive: true });
 	}
 
 	/**
@@ -139,7 +139,7 @@ class RestClient {
 				port: 443,
 				path: `/${cdn ? "" : `api/v${this.version}/`}${path.split("/").filter(Boolean).join("/")}`,
 				method: method.toUpperCase(),
-				agent: this._agent,
+				agent: this.agent,
 				headers: {
 					"User-Agent": `DiscordBot (https://github.com/timotejroiko/tiny-discord, ${require("../package.json").version}) Node.js/${process.version}`,
 					...headers,
@@ -240,6 +240,7 @@ module.exports = RestClient;
  * 		type?: "bot" | "bearer",
  * 		retries?: number,
  * 		timeout?: number
+ * 		agent?: import("https").Agent
  * }} RestClientOptions
  */
 

--- a/src/WebsocketShard.js
+++ b/src/WebsocketShard.js
@@ -28,6 +28,7 @@ class WebsocketShard extends EventEmitter {
 		this.encoding = typeof options.encoding === "string" && options.encoding.toLowerCase() === "etf" ? "etf" : "json";
 		this.compression = [0, 1, 2].includes(options.compression = /** @type {0 | 1 | 2} */ (Number(options.compression))) ? options.compression : 0;
 		this.url = typeof options.url === "string" ? options.url.includes("://") ? options.url.split("://")[1] : options.url : "gateway.discord.gg";
+		this.agent = options.agent || null;
 		this.disabledEvents = Array.isArray(options.disabledEvents) ? options.disabledEvents : null;
 		this.etfUseBigint = Boolean(options.etfUseBigint);
 		this.identifyHook = typeof options.identifyHook === "function" ? options.identifyHook : null;
@@ -371,7 +372,8 @@ class WebsocketShard extends EventEmitter {
 				"Upgrade": "websocket",
 				"Sec-WebSocket-Key": key,
 				"Sec-WebSocket-Version": "13",
-			}
+			},
+			agent: this.agent
 		});
 		return new Promise((resolve, reject) => {
 			req.on("upgrade", (res, socket) => {
@@ -1251,6 +1253,7 @@ module.exports = WebsocketShard;
  * 		encoding?: "etf" | "json",
  * 		compression?: 0 | 1 | 2,
  * 		url?: string,
+ * 		agent?: import("https").Agent,
  * 		session?: {
  * 			session_id: string,
  * 			sequence: number,

--- a/types/src/RestClient.d.ts
+++ b/types/src/RestClient.d.ts
@@ -50,6 +50,7 @@ type RestClientOptions = {
     type?: "bot" | "bearer";
     retries?: number;
     timeout?: number;
+    agent?: import("https").Agent | undefined;
 };
 type FileObject = {
     name: string;

--- a/types/src/RestClient.d.ts
+++ b/types/src/RestClient.d.ts
@@ -7,7 +7,7 @@ declare class RestClient {
     type: string;
     retries: number;
     timeout: number;
-    private _agent;
+    agent: import("https").Agent | undefined;
     get(path: RequestOptions["path"], options?: RequestOptions["options"]): AbortablePromise<RequestResult>;
     delete(path: RequestOptions["path"], options?: RequestOptions["options"]): AbortablePromise<RequestResult>;
     post(path: RequestOptions["path"], body: RequestOptions["body"], options?: RequestOptions["options"]): AbortablePromise<RequestResult>;

--- a/types/src/WebsocketShard.d.ts
+++ b/types/src/WebsocketShard.d.ts
@@ -12,6 +12,7 @@ declare class WebsocketShard extends EventEmitter {
     encoding: string;
     compression: 0 | 2 | 1;
     url: string;
+    agent: import("https").Agent | undefined;
     disabledEvents: string[] | null;
     etfUseBigint: boolean;
     identifyHook: ((id: number) => {

--- a/types/src/WebsocketShard.d.ts
+++ b/types/src/WebsocketShard.d.ts
@@ -158,6 +158,7 @@ type WebsocketShardOptions = {
     encoding?: "etf" | "json" | undefined;
     compression?: 0 | 2 | 1 | undefined;
     url?: string | undefined;
+    agent?: import("https").Agent | undefined;
     session?: {
         session_id: string;
         sequence: number;


### PR DESCRIPTION
Allows passing a custom `Agent` to `WebsocketShard` and `RestClient`, closes #3.

Example usage: 
```js
const WebsocketShard = require('../src/WebsocketShard.js');
const RestClient = require('../src/RestClient.js');
const {SocksProxyAgent} = require('socks-proxy-agent');

const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
const SOCKS_PROXY_URL = process.env.SOCKS_PROXY_URI;

const agent = new SocksProxyAgent(SOCKS_PROXY_URL, {
  keepAlive: true
});

// Usage with WebsocketShard
const shard = new WebsocketShard({
  intents: 0,
  token: DISCORD_TOKEN,
  agent,
});

shard
  .on('ready', ({ data }) => {
    const { country_code } = data;

    console.log('Successfully connected to gateway in region', country_code);
    shard.close();
  })
  .connect();


// Usage with RestClient
const restClient = new RestClient({
  token: DISCORD_TOKEN,
  agent,
});

restClient.get('/users/@me').then(resp => {
  console.log(resp.body.json);
});
```